### PR TITLE
Fix configs resetting on Runelite accounts (and update RLversion)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.0.1'
+def runeLiteVersion = '1.6.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
@@ -29,7 +29,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("com/suppliestracker")
+@ConfigGroup("suppliestracker")
 public interface SuppliesTrackerConfig extends Config
 {
 	@ConfigItem(


### PR DESCRIPTION
Resolves #5 

As per Alex in the RL Discord as to why the `com/` broke it:

> the db reads those as something else i think
>thats why everything is deliniated with .