### PR TITLE
Add missing ava's-effect capes

### DIFF
--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -412,6 +412,8 @@ public class SuppliesTrackerPlugin extends Plugin
 				case AVAS_ASSEMBLER:
 				case AVAS_ASSEMBLER_L:
 				case ASSEMBLER_MAX_CAPE:
+				case ASSEMBLER_MAX_CAPE_L:
+				case MAX_CAPE_13342:
 					percent = ASSEMBLER_PERCENT;
 					break;
 				case AVAS_ACCUMULATOR:
@@ -419,6 +421,7 @@ public class SuppliesTrackerPlugin extends Plugin
 				case ACCUMULATOR_MAX_CAPE:
 					// TODO: the ranging cape can be used as an attractor so this could be wrong
 				case RANGING_CAPE:
+				case RANGING_CAPET:
 					percent = ACCUMULATOR_PERCENT;
 					break;
 				case AVAS_ATTRACTOR:


### PR DESCRIPTION
Adds the following to getAccumulatorPercent:

Assembler Max Cape (L)
Max Cape (13342 is the ID of the equipped max cape; it has a different inventory ID)
Ranging Cape (T)

I have made the assumption that anyone who has a max cape has attached a vorkath head to their cape, giving it the assembler percent.  I've added Ranging Cape T to the accumulator case, although I assume you mean "assembler" instead of "attractor" in your `TODO`.