### PR TITLE
Add check and config for vorkath's head attachment to capes

### DIFF
--- a/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
@@ -61,4 +61,14 @@ public interface SuppliesTrackerConfig extends Config
 {
 	return false;
 }
+
+	@ConfigItem(
+		keyName = "vorkathsHead",
+		name = "Attached Vorkath's head?",
+		description = "Whether or not you attached a Vorkath's head to your Ranging cape for Assembler effect."
+	)
+	default boolean vorkathsHead()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -407,23 +407,50 @@ public class SuppliesTrackerPlugin extends Plugin
 		if (equipment != null && equipment.getItems().length > EQUIPMENT_CAPE_SLOT)
 		{
 			int capeID = equipment.getItems()[EQUIPMENT_CAPE_SLOT].getId();
-			switch (capeID)
+
+			if (config.vorkathsHead())
 			{
-				case AVAS_ASSEMBLER:
-				case AVAS_ASSEMBLER_L:
-				case ASSEMBLER_MAX_CAPE:
-					percent = ASSEMBLER_PERCENT;
-					break;
-				case AVAS_ACCUMULATOR:
-				case AVAS_ACCUMULATOR_23609:
-				case ACCUMULATOR_MAX_CAPE:
-					// TODO: the ranging cape can be used as an attractor so this could be wrong
-				case RANGING_CAPE:
-					percent = ACCUMULATOR_PERCENT;
-					break;
-				case AVAS_ATTRACTOR:
-					percent = ATTRACTOR_PERCENT;
-					break;
+				switch (capeID)
+				{
+					case ASSEMBLER_MAX_CAPE:
+					case ASSEMBLER_MAX_CAPE_L:
+					case AVAS_ASSEMBLER:
+					case AVAS_ASSEMBLER_L:
+					case MAX_CAPE_13342:
+					case RANGING_CAPE:
+					case RANGING_CAPET:
+						percent = ASSEMBLER_PERCENT;
+						break;
+					case ACCUMULATOR_MAX_CAPE:
+					case AVAS_ACCUMULATOR:
+						percent = ACCUMULATOR_PERCENT;
+						break;
+					case AVAS_ATTRACTOR:
+						percent = ATTRACTOR_PERCENT;
+						break;
+				}
+			}
+			else
+			{
+				switch (capeID)
+				{
+					case ASSEMBLER_MAX_CAPE:
+					case ASSEMBLER_MAX_CAPE_L:
+					case AVAS_ASSEMBLER:
+					case AVAS_ASSEMBLER_L:
+						percent = ASSEMBLER_PERCENT;
+						break;
+					case ACCUMULATOR_MAX_CAPE:
+					case AVAS_ACCUMULATOR:
+					case MAX_CAPE_13342:
+					case RANGING_CAPE:
+					case RANGING_CAPET:
+						percent = ACCUMULATOR_PERCENT;
+						break;
+					case AVAS_ATTRACTOR:
+						percent = ATTRACTOR_PERCENT;
+						break;
+				}
 			}
 		}
 		return percent;


### PR DESCRIPTION
It is possible to attach a Vorkath's head to the Ranging cape/Ranging cape (T)/Max Cape (attach to one and it affects them all) to give it the ammo saving effect of the Assembler. This commit enables the user to configure whether or not they have attached the head to their cape so the supplies tracking for ranging can be more accurate.

In addition:

Removed AVAS_ACCUMULATOR_23609 as that was from LMS and has since been removed from the game

Added ASSEMBLER_MAX_CAPE_L

Added MAX_CAPE_13342

Added RANGING_CAPET

Supersedes #21 