### PR TITLE
Add Wilderness weapon tracking

### DIFF
--- a/src/main/java/com/suppliestracker/ItemType.java
+++ b/src/main/java/com/suppliestracker/ItemType.java
@@ -77,7 +77,7 @@ public enum ItemType
 			|| item.getName().toLowerCase().contains("knive") || item.getName().toLowerCase().contains("throwing")
 			|| item.getName().toLowerCase().contains("zulrah's scale") || item.getName().toLowerCase().contains("cannonball")
 			|| item.getName().toLowerCase().contains("knife")|| item.getName().toLowerCase().contains("chinchompa")
-			|| item.getName().toLowerCase().contains("thrownaxe"))
+			|| item.getName().toLowerCase().contains("thrownaxe") || item.getId() == REVENANT_ETHER)
 		{
 			return ItemType.AMMO;
 		}
@@ -105,7 +105,9 @@ public enum ItemType
 		}
 		else if (item.getId() == SCYTHE_OF_VITUR || item.getId() == SANGUINESTI_STAFF ||
 				item.getId() == TRIDENT_OF_THE_SEAS || item.getId() == TRIDENT_OF_THE_SWAMP ||
-				item.getId() == BLADE_OF_SAELDOR || item.getId() == IBANS_STAFF)
+				item.getId() == BLADE_OF_SAELDOR || item.getId() == IBANS_STAFF ||
+				item.getId() == THAMMARONS_SCEPTRE || item.getId() == CRAWS_BOW ||
+				item.getId() == VIGGORAS_CHAINMACE)
 		{
 			return ItemType.CHARGES;
 		}

--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -161,6 +161,13 @@ public class SuppliesTrackerPlugin extends Plugin
 	private static final int ENSOULED_HEADS_ANIMATION = 7198;
 	private static final int IBANS_STAFF_ANIMATION = 708;
 	private static final int SLAYERS_STAFF_ANIMATION = 1576;
+	private static final int ENTANGLE_ANIMATION = 1161;
+	private static final int VULNERABILITY_ANIMATION = 1165;
+	private static final int CRUMBLE_UNDEAD_ANIMATION = 1166;
+	private static final int ENFEEBLE_ANIMATION = 1168;
+	private static final int STUN_ANIMATION = 1169;
+	private static final int BOW_SHOOT_ANIMATION = 426;
+	private static final int CHAINMACE_ANIMATION = 245;
 	private final Deque<MenuAction> actionStack = new ArrayDeque<>();
 
 	//Item arrays
@@ -634,13 +641,29 @@ public class SuppliesTrackerPlugin extends Plugin
 					}
 					// let case fall through to handle non-charge path through regular cast path
 					// to prevent double counting when manually casting from the spell book.
-				case SLAYERS_STAFF_ANIMATION:
 				case LOW_LEVEL_MAGIC_ATTACK:
 				case BARRAGE_ANIMATION:
 				case BLITZ_ANIMATION:
 				case LOW_LEVEL_STANDARD_SPELLS:
 				case WAVE_SPELL_ANIMATION:
 				case SURGE_SPELL_ANIMATION:
+				case ENTANGLE_ANIMATION:
+				case ENFEEBLE_ANIMATION:
+				case VULNERABILITY_ANIMATION:
+				case STUN_ANIMATION:
+				case CRUMBLE_UNDEAD_ANIMATION:
+					if (mainHand == THAMMARONS_SCEPTRE)
+					{
+						if (config.chargesBox())
+						{
+							buildChargesEntries(THAMMARONS_SCEPTRE);
+						}
+						else
+						{
+							buildEntries(REVENANT_ETHER, 1);
+						}
+					}
+				case SLAYERS_STAFF_ANIMATION:
 				case HIGH_ALCH_ANIMATION:
 				case LUNAR_HUMIDIFY:
 					old = client.getItemContainer(InventoryID.INVENTORY);
@@ -656,6 +679,32 @@ public class SuppliesTrackerPlugin extends Plugin
 					{
 						skipTick = true;
 						noXpCast = true;
+					}
+					break;
+				case BOW_SHOOT_ANIMATION:
+					if (mainHand == CRAWS_BOW)
+					{
+						if (config.chargesBox())
+						{
+							buildChargesEntries(CRAWS_BOW);
+						}
+						else
+						{
+							buildEntries(REVENANT_ETHER, 1);
+						}
+					}
+					break;
+				case CHAINMACE_ANIMATION:
+					if (mainHand == VIGGORAS_CHAINMACE)
+					{
+						if (config.chargesBox())
+						{
+							buildChargesEntries(VIGGORAS_CHAINMACE);
+						}
+						else
+						{
+							buildEntries(REVENANT_ETHER, 1);
+						}
 					}
 					break;
 				case SCYTHE_OF_VITUR_ANIMATION:
@@ -1368,6 +1417,11 @@ public class SuppliesTrackerPlugin extends Plugin
 				break;
 			case BLADE_OF_SAELDOR:
 				calculatedPrice = 0;
+				break;
+			case THAMMARONS_SCEPTRE:
+			case CRAWS_BOW:
+			case VIGGORAS_CHAINMACE:
+				calculatedPrice = (itemManager.getItemPrice(REVENANT_ETHER));
 				break;
 		}
 

--- a/src/main/java/com/suppliestracker/ui/SuppliesBox.java
+++ b/src/main/java/com/suppliestracker/ui/SuppliesBox.java
@@ -551,6 +551,18 @@ public abstract class SuppliesBox extends JPanel
 						.append("gp")
 						.append("</html>");
 					return tooltip.toString();
+
+				case THAMMARONS_SCEPTRE:
+				case CRAWS_BOW:
+				case VIGGORAS_CHAINMACE:
+					tooltip.append("<html>")
+						.append("Revenant ether x ")
+						.append(qty)
+						.append(" (")
+						.append(QuantityFormatter.quantityToStackSize(item.getPrice()))
+						.append("gp)")
+						.append("</html>");
+					return tooltip.toString();
 			}
 
 			return tooltip.toString();


### PR DESCRIPTION
Closes #26 

I don't believe the added animations for the Sceptre will have any negative effect on L669-683 of `SuppliesTrackerPlugin` (hence the deliberate omission of a `break;` in the added code).